### PR TITLE
Fixed an occasional crash on Windows

### DIFF
--- a/src/winapi.rs
+++ b/src/winapi.rs
@@ -26,10 +26,13 @@ impl ConnectionTrait for Connection {
 unsafe extern "system" fn enumerate_windows(window: HWND, state: LPARAM) -> BOOL {
     if IsWindowVisible(window) == 0 { return true.into() }
     let state = state as *mut Vec<String>;
-    let length = GetWindowTextLengthW(window);
+    let mut length = GetWindowTextLengthW(window);
+    if length == 0 { return true.into() }
+    length = length + 1;
     let mut title: Vec<u16> = vec![0; length as usize];
-    if GetWindowTextW(window, title.as_mut_ptr() as LPWSTR, length+1) != 0 {
-        if let Ok(title) = String::from_utf16(title[0..(length as usize)].as_ref()) {
+    let textw = GetWindowTextW(window, title.as_mut_ptr() as LPWSTR, length);
+    if textw != 0 {
+        if let Ok(title) = String::from_utf16(title[0..(textw as usize)].as_ref()) {
             (*state).push(title);
         }
     }


### PR DESCRIPTION
Hello, first of all thank you for making this! :)

Many months ago when I started using window_titles I found an issue where sometimes (or all the times, cannot remember) the title would be cut one character short. E.g. "Firefox" -> "Firefo" and sometimes it would just crash.

I somehow fixed it.. at least it doesn't crash for me anymore and seems to work as intended. I wanted to do this pull request months ago but kinda forgot.