### PR TITLE
Fix: Mac single " in window title + Windows Memory Leak + Mac OSAC Command Execution Fails Fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Hiruna Jayamanne <hiru@hiru.dev>"]
 edition = "2018"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-xcb = "0.9"
+xcb = "1.3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["winnt", "winuser", "minwindef"] }

--- a/src/winapi.rs
+++ b/src/winapi.rs
@@ -12,7 +12,7 @@ pub struct Connection;
 impl ConnectionTrait for Connection {
     fn new() -> Result<Self> { Ok(Self) }
     fn window_titles(&self) -> Result<Vec<String>> {
-        let state: Box<Vec<String>> = Box::new(Vec::new());
+        let state: Box<Vec<String>> = Box::new(Vec::with_capacity(1000));
         let ptr = Box::into_raw(state);
         let state;
         unsafe {


### PR DESCRIPTION
- In certain scenarios, my window title contains only a single quotation mark. This update resolves the problem of invoking unwrap on a None value, which occurs when the find method returns None due to an excess of single quotes. I have also included a test for this fix. 

- Address the reallocation issue that may lead to a memory leak on Windows. Implement a default size for allocations.

- Switched to a Character based approach incase titles go outside 8 bytes. Such as 😄 emojis 

- Handling mac OSA Script Failure

- Updated XCB Crate to Latest